### PR TITLE
Add ForceRedirectUriSchemeHttps option.

### DIFF
--- a/Owin.Security.Providers.PingFederate/PingFederateAuthenticationHandler.cs
+++ b/Owin.Security.Providers.PingFederate/PingFederateAuthenticationHandler.cs
@@ -117,7 +117,7 @@ namespace Owin.Security.Providers.PingFederate
                 var context = new PingFederateAuthenticatingContext(this.Context, this.Options);
                 await this.Options.Provider.Authenticating(context);
 
-                var baseUri = this.Request.Scheme + Uri.SchemeDelimiter + this.Request.Host + this.Request.PathBase;
+                var baseUri = Scheme() + Uri.SchemeDelimiter + this.Request.Host + this.Request.PathBase;
                 var currentUri = baseUri + this.Request.Path + this.Request.QueryString; 
                 var redirectUri = baseUri + this.Options.CallbackPath;
 
@@ -215,7 +215,7 @@ namespace Owin.Security.Providers.PingFederate
                 var tokenRequestContext = new PingFederateTokenRequestContext(this.Context, this.Options, state, code, properties);
                 await this.Options.Provider.TokenRequest(tokenRequestContext);
 
-                var requestPrefix = this.Request.Scheme + Uri.SchemeDelimiter + this.Request.Host + this.Request.PathBase;
+                var requestPrefix = Scheme() + Uri.SchemeDelimiter + this.Request.Host + this.Request.PathBase;
                 var redirectUri = requestPrefix + Options.CallbackPath;
 
                 // Build up the body for the token request
@@ -524,7 +524,12 @@ namespace Owin.Security.Providers.PingFederate
             var baseUri = this.Request.Scheme + Uri.SchemeDelimiter + this.Request.Host + this.Request.PathBase;
             var redirectUri = baseUri + "/" + this.Options.ErrorPath;
             return redirectUri;
-        }     
+        }
+
+        private string Scheme()
+        {
+            return this.Options.ForceRedirectUriSchemeHttps ? Uri.UriSchemeHttps : this.Request.Scheme;
+        }
 
         #endregion
     }

--- a/Owin.Security.Providers.PingFederate/PingFederateAuthenticationOptions.cs
+++ b/Owin.Security.Providers.PingFederate/PingFederateAuthenticationOptions.cs
@@ -199,6 +199,11 @@ namespace Owin.Security.Providers.PingFederate
         /// </summary>
         public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
 
+        /// <summary>
+        ///     Gets or sets a value indicating whether to force the use of Uri.UriSchemeHttps for redirect Uri. Default is false
+        /// </summary>
+        public bool ForceRedirectUriSchemeHttps { get; set; }
+
         #endregion
     }
 }


### PR DESCRIPTION
This flag forces the use of HTTPS on the redirect Url in scenarios where the originating request uses the HTTPS protocol.
