### PR TITLE
Fix access_denied issue

### DIFF
--- a/.nuget/pack.ps1
+++ b/.nuget/pack.ps1
@@ -1,5 +1,5 @@
 $root = $env:APPVEYOR_BUILD_FOLDER
-$version = [System.Reflection.Assembly]::LoadFile("$root\Owin.Security.Providers.PingFederate\bin\Release\Owin.Security.Providers.PingFederate.dll").GetName().Version
+$version = [System.Reflection.AssemblyName]::GetAssemblyName("$root\Owin.Security.Providers.PingFederate\bin\Release\Owin.Security.Providers.PingFederate.dll").Version
 $versionStr = "{0}.{1}.{2}" -f ($version.Major, $version.Minor, $version.Build)
 
 Write-Host "Setting .nuspec version tag to $versionStr"

--- a/Owin.Security.Providers.PingFederate.sln
+++ b/Owin.Security.Providers.PingFederate.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Owin.Security.Providers.PingFederate", "Owin.Security.Providers.PingFederate\Owin.Security.Providers.PingFederate.csproj", "{292035DD-75CB-4109-88FD-33ED35C42A33}"
 EndProject
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{BDED25
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\pack.ps1 = .nuget\pack.ps1
 	EndProjectSection
 EndProject
 Global

--- a/Owin.Security.Providers.PingFederate/Provider/PingFederateAuthenticatedContext.cs
+++ b/Owin.Security.Providers.PingFederate/Provider/PingFederateAuthenticatedContext.cs
@@ -51,7 +51,7 @@ namespace Owin.Security.Providers.PingFederate.Provider
             this.Id = TryGetValue(user, "sub");
             this.Name = TryGetValue(user, "name");
             this.Link = TryGetValue(user, "website");
-            this.UserName = TryGetValue(user, "preferred_username");
+            this.UserName = TryGetValue(user, "preferred_username") ?? TryGetValue(user, "sub");
             this.Email = TryGetValue(user, "email");
         }
 

--- a/Owin.Security.Providers.PingFederate/Provider/PingFederateAuthenticationHandlerFactory.cs
+++ b/Owin.Security.Providers.PingFederate/Provider/PingFederateAuthenticationHandlerFactory.cs
@@ -23,9 +23,6 @@ namespace Owin.Security.Providers.PingFederate.Provider
     {
         #region Fields
 
-        /// <summary>The http client.</summary>
-        private readonly HttpClient httpClient;
-
         /// <summary>The logger.</summary>
         private readonly ILogger logger;
 
@@ -34,11 +31,9 @@ namespace Owin.Security.Providers.PingFederate.Provider
         #region Constructors and Destructors
 
         /// <summary>Initializes a new instance of the <see cref="PingFederateAuthenticationHandlerFactory"/> class. Initializes a new instance of the <see cref="T:System.Object"/> class.</summary>
-        /// <param name="httpClient">The http Client.</param>
         /// <param name="logger">The logger.</param>
-        public PingFederateAuthenticationHandlerFactory(HttpClient httpClient, ILogger logger)
+        public PingFederateAuthenticationHandlerFactory(ILogger logger)
         {
-            this.httpClient = httpClient;
             this.logger = logger;
         }
 
@@ -50,7 +45,7 @@ namespace Owin.Security.Providers.PingFederate.Provider
         /// <returns>The <see cref="AuthenticationHandler" />.</returns>
         public AuthenticationHandler<PingFederateAuthenticationOptions> CreateHandler()
         {
-            return new PingFederateAuthenticationHandler(this.httpClient, this.logger);
+            return new PingFederateAuthenticationHandler(this.logger);
         }
 
         #endregion


### PR DESCRIPTION
Hello,
I had access_denied error when I wanted to authenticate my application to our Ping Federate instance.
After some modifications on your code, it works fine.

I propose you the following modifications:
- Change the way to use HttpClient object: as it is a disposable object, it's recommended to instantiate it only when you need to perform a call. So, I have defined methods for GET and POST calls on handler side instead of having a global httpclient at middleware level
- I have also changed the UserName value when you retrieve user object, in order to map sub property when preferred_username property is not defined (our instance is configured to get only sub property)
- I have changed the way to get assembly version, because I had an issue to clean assembly each time I compile after running the tool to generate NuGet package